### PR TITLE
Writing to a characteristic with a `withoutResponse` write type will immediately end the returned publisher

### DIFF
--- a/CentralPeripheralDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/CentralPeripheralDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CentralPeripheralDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CentralPeripheralDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CentralPeripheralDemo/Assets.xcassets/Contents.json
+++ b/CentralPeripheralDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CentralPeripheralDemo/CentralView.swift
+++ b/CentralPeripheralDemo/CentralView.swift
@@ -1,0 +1,217 @@
+//
+//  ContentView.swift
+//  CentralDemo
+//
+//  Created by Kevin Lundberg on 3/27/22.
+//
+
+import CombineCoreBluetooth
+import SwiftUI
+
+class CentralDemo: ObservableObject {
+  let centralManager: CentralManager = .live()
+  @Published var peripherals: [PeripheralDiscovery] = []
+  @Published var peripheralConnectResult: Result<Peripheral, Error>?
+  var cancellables: Set<AnyCancellable> = []
+
+  var connectedPeripheral: Peripheral? {
+    guard case let .success(value) = peripheralConnectResult else { return nil }
+    return value
+  }
+
+  var connectError: Error? {
+    guard case let .failure(value) = peripheralConnectResult else { return nil }
+    return value
+  }
+
+  func searchForPeripherals() {
+    centralManager.scanForPeripherals(withServices: [CBUUID.service])
+      .scan([], { list, discovery -> [PeripheralDiscovery] in
+        guard !list.contains(where: { $0.id == discovery.id }) else { return list }
+        return list + [discovery]
+      })
+      .receive(on: DispatchQueue.main)
+      .assign(to: &$peripherals)
+  }
+
+  func connect(_ discovery: PeripheralDiscovery) {
+    centralManager.connect(discovery.peripheral)
+      .map(Result.success)
+      .catch({ Just(Result.failure($0)) })
+        .receive(on: DispatchQueue.main)
+        .assign(to: &$peripheralConnectResult)
+  }
+}
+
+class PeripheralDevice: ObservableObject {
+  let peripheral: Peripheral
+  init(_ peripheral: Peripheral) {
+    self.peripheral = peripheral
+  }
+
+  @Published var writeResponseResult: Result<Date, Error>?
+  @Published var writeNoResponseResult: Result<Date, Error>? // never should be set
+  @Published var writeResponseOrNoResponseResult: Result<Date, Error>?
+
+  func write(
+    to id: CBUUID,
+    type: CBCharacteristicWriteType,
+    result: ReferenceWritableKeyPath<PeripheralDevice, Published<Result<Date, Error>?>.Publisher>
+  ) {
+    writeResponseResult = nil
+
+    peripheral.writeValue(
+      Data("Hello".utf8),
+      writeType: type,
+      forCharacteristic: id,
+      inService: .service
+    )
+    .receive(on: DispatchQueue.main)
+    .map { _ in Result<Date, Error>.success(Date()) }
+    .catch { e in Just(Result.failure(e)) }
+    .assign(to: &self[keyPath: result])
+  }
+
+  func writeWithoutResponse(to id: CBUUID) {
+    writeNoResponseResult = nil
+
+    peripheral.writeValue(
+      Data("Hello".utf8),
+      writeType: .withoutResponse,
+      forCharacteristic: id,
+      inService: .service
+    )
+    .receive(on: DispatchQueue.main)
+    .map { _ in Result<Date, Error>.success(Date()) }
+    .catch { e in Just(Result.failure(e)) }
+    .assign(to: &$writeNoResponseResult)
+  }
+}
+
+struct CentralView: View {
+  @StateObject var demo: CentralDemo = .init()
+
+  var body: some View {
+    if let device = demo.connectedPeripheral {
+      PeripheralDeviceView(device, demo)
+    } else {
+      Form {
+        Section {
+          Button("Search for peripheral") {
+            demo.searchForPeripherals()
+          }
+
+          if let error = demo.connectError {
+            Text("Error: \(String(describing: error))")
+          }
+
+          ForEach(demo.peripherals) { discovery in
+            Button(discovery.peripheral.name ?? "<nil>") {
+              demo.connect(discovery)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+struct PeripheralDeviceView: View {
+  @ObservedObject var device: PeripheralDevice
+  @ObservedObject var demo: CentralDemo
+
+  init(_ peripheral: Peripheral, _ demo: CentralDemo) {
+    self.device = .init(peripheral)
+    self.demo = demo
+  }
+
+  var body: some View {
+    Form {
+      Section("Characteristic sends response") {
+        Button(action: {
+          device.write(
+            to: .writeResponseCharacteristic,
+            type: .withResponse,
+            result: \PeripheralDevice.$writeResponseResult
+          )
+        }) {
+          Text("Write with response")
+        }
+        Button(action: {
+          device.write(
+            to: .writeResponseCharacteristic,
+            type: .withoutResponse,
+            result: \PeripheralDevice.$writeResponseResult
+          )
+        }) {
+          Text("Write without response")
+        }
+        label(for: device.writeResponseResult)
+      }
+
+      Section("Characteristic doesn't send response") {
+        Button(action: {
+          device.write(
+            to: .writeNoResponseCharacteristic,
+            type: .withResponse,
+            result: \PeripheralDevice.$writeNoResponseResult
+          )
+        }) {
+          Text("Write with response")
+        }
+        Button(action: {
+          device.write(
+            to: .writeNoResponseCharacteristic,
+            type: .withoutResponse,
+            result: \PeripheralDevice.$writeNoResponseResult
+          )
+        }) {
+          Text("Write without response")
+        }
+        label(for: device.writeNoResponseResult)
+      }
+
+      Section("Characteristic can both send or not send response") {
+        Button(action: {
+          device.write(
+            to: .writeBothResponseAndNoResponseCharacteristic,
+            type: .withResponse,
+            result: \PeripheralDevice.$writeResponseOrNoResponseResult
+          )
+        }) {
+          Text("Write with response")
+        }
+        Button(action: {
+          device.write(
+            to: .writeBothResponseAndNoResponseCharacteristic,
+            type: .withoutResponse,
+            result: \PeripheralDevice.$writeResponseOrNoResponseResult
+          )
+        }) {
+          Text("Write without response")
+        }
+
+        label(for: device.writeResponseOrNoResponseResult)
+      }
+    }
+  }
+
+  func label<T>(for result: Result<T, Error>?) -> some View {
+    Group {
+      switch result {
+      case let .success(value)?:
+        Text("Wrote at \(String(describing: value))")
+      case let .failure(error)?:
+        Text("Error: \(String(describing: error))")
+      case nil:
+        EmptyView()
+      }
+    }
+  }
+}
+
+struct ContentView_Previews: PreviewProvider {
+  static var previews: some View {
+    CentralView()
+  }
+}

--- a/CentralPeripheralDemo/Info.plist
+++ b/CentralPeripheralDemo/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/CentralPeripheralDemo/PeripheralDemoApp.swift
+++ b/CentralPeripheralDemo/PeripheralDemoApp.swift
@@ -1,0 +1,36 @@
+//
+//  PeripheralDemoApp.swift
+//  PeripheralDemo
+//
+//  Created by Kevin Lundberg on 3/25/22.
+//
+
+import SwiftUI
+
+@main
+struct PeripheralDemoApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}
+
+struct ContentView: View {
+  var body: some View {
+    NavigationView {
+      Form {
+        Section("Warning: if you run this in the iOS simulator, live bluetooth communication will not work, as CoreBluetooth does not function in the simulator. Run as a mac/mac catalyst app instead.") {
+          NavigationLink("Simulate a peripheral") {
+            PeripheralView()
+              .navigationTitle("Peripheral")
+          }
+          NavigationLink("Simulate a central") {
+            CentralView()
+              .navigationTitle("Central")
+          }
+        }
+      }
+    }
+  }
+}

--- a/CentralPeripheralDemo/PeripheralView.swift
+++ b/CentralPeripheralDemo/PeripheralView.swift
@@ -1,0 +1,121 @@
+//
+//  ContentView.swift
+//  PeripheralDemo
+//
+//  Created by Kevin Lundberg on 3/25/22.
+//
+
+import SwiftUI
+import CombineCoreBluetooth
+
+extension CBUUID {
+  static let service = CBUUID(string: "1337")
+  static let writeResponseCharacteristic = CBUUID(string: "0001")
+  static let writeNoResponseCharacteristic = CBUUID(string: "0002")
+  static let writeBothResponseAndNoResponseCharacteristic = CBUUID(string: "0003")
+}
+
+class PeripheralDemo: ObservableObject {
+  let peripheralManager = PeripheralManager.live
+  @Published var logs: String = ""
+  var cancellables = Set<AnyCancellable>()
+  @Published var advertising: Bool = false
+
+  init() {
+    peripheralManager.didReceiveWriteRequests
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] requests in
+        guard let self = self else { return }
+        print(requests.map({ r in
+          "Write to \(r.characteristic.uuid), value: \(String(bytes: r.value ?? Data(), encoding: .utf8) ?? "<nil>")"
+        }), to: &self.logs)
+
+        self.peripheralManager.respond(to: requests[0], withResult: .success)
+      }.store(in: &cancellables)
+  }
+
+  func buildServices() {
+    let service1 = CBMutableService(type: .service, primary: true)
+    let writeCharacteristic = CBMutableCharacteristic(
+      type: .writeResponseCharacteristic,
+      properties: .write,
+      value: nil,
+      permissions: .writeable
+    )
+    let writeNoResponseCharacteristic = CBMutableCharacteristic(
+      type: .writeNoResponseCharacteristic,
+      properties: .writeWithoutResponse,
+      value: nil,
+      permissions: .writeable
+    )
+    let writeWithOrWithoutResponseCharacteristic = CBMutableCharacteristic(
+      type: .writeBothResponseAndNoResponseCharacteristic,
+      properties: [.write, .writeWithoutResponse],
+      value: nil,
+      permissions: .writeable
+    )
+
+    service1.characteristics = [
+      writeCharacteristic,
+      writeNoResponseCharacteristic,
+      writeWithOrWithoutResponseCharacteristic,
+    ]
+    peripheralManager.removeAllServices()
+    peripheralManager.add(service1)
+  }
+
+  func start() {
+    if peripheralManager.state == .poweredOn {
+      buildServices()
+      peripheralManager.startAdvertising(.init([.serviceUUIDs: [CBUUID.service]]))
+      advertising = true
+    } else {
+      // once bt is powered on, advertise
+      peripheralManager.didUpdateState
+        .first(where: { $0 == .poweredOn })
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+          self?.start()
+        }
+        .store(in: &cancellables)
+    }
+  }
+
+  func stop() {
+    peripheralManager.stopAdvertising()
+    cancellables = []
+    advertising = false
+  }
+}
+
+struct PeripheralView: View {
+  @StateObject var peripheral: PeripheralDemo = .init()
+
+  var body: some View {
+    Form {
+      Section("Device that simulates a peripheral with various kinds of characteristics.") {
+
+        if peripheral.advertising {
+          Button("Stop advertising") { peripheral.stop() }
+        } else {
+          Button("Start advertising") { peripheral.start() }
+        }
+
+        Text("Logs:")
+        Text(peripheral.logs)
+      }
+    }
+    .onAppear {
+      peripheral.start()
+    }
+    .onDisappear {
+      peripheral.stop()
+    }
+  }
+}
+
+struct PeripheralView_Previews: PreviewProvider {
+  static var previews: some View {
+    PeripheralView()
+  }
+}

--- a/CentralPeripheralDemo/PeripheralView.swift
+++ b/CentralPeripheralDemo/PeripheralView.swift
@@ -28,7 +28,7 @@ class PeripheralDemo: ObservableObject {
         guard let self = self else { return }
         print(requests.map({ r in
           "Write to \(r.characteristic.uuid), value: \(String(bytes: r.value ?? Data(), encoding: .utf8) ?? "<nil>")"
-        }), to: &self.logs)
+        }).joined(separator: "\n"), to: &self.logs)
 
         self.peripheralManager.respond(to: requests[0], withResult: .success)
       }.store(in: &cancellables)

--- a/CentralPeripheralDemo/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/CentralPeripheralDemo/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CombineCoreBluetooth.xcodeproj/project.pbxproj
+++ b/CombineCoreBluetooth.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0014FFB227F0359600D2A122 /* CombineCoreBluetooth in Frameworks */ = {isa = PBXBuildFile; productRef = 0014FFB127F0359600D2A122 /* CombineCoreBluetooth */; };
+		003719FB27EE588900C2F766 /* PeripheralDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003719FA27EE588900C2F766 /* PeripheralDemoApp.swift */; };
+		003719FD27EE588900C2F766 /* PeripheralView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003719FC27EE588900C2F766 /* PeripheralView.swift */; };
+		003719FF27EE588C00C2F766 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 003719FE27EE588C00C2F766 /* Assets.xcassets */; };
+		00371A0227EE588C00C2F766 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 00371A0127EE588C00C2F766 /* Preview Assets.xcassets */; };
+		00371A2327F02B1900C2F766 /* CentralView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00371A2227F02B1900C2F766 /* CentralView.swift */; };
 		EB443FB927C6BDE10005CCEA /* Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443F9C27C6BDE00005CCEA /* Exports.swift */; };
 		EB443FBA27C6BDE10005CCEA /* PassthroughBacked.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443F9D27C6BDE00005CCEA /* PassthroughBacked.swift */; };
 		EB443FBB27C6BDE10005CCEA /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443F9E27C6BDE00005CCEA /* Publisher+Extensions.swift */; };
@@ -45,6 +51,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0014FFB027F032C000D2A122 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		003719F827EE588900C2F766 /* CentralPeripheralDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CentralPeripheralDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		003719FA27EE588900C2F766 /* PeripheralDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralDemoApp.swift; sourceTree = "<group>"; };
+		003719FC27EE588900C2F766 /* PeripheralView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralView.swift; sourceTree = "<group>"; };
+		003719FE27EE588C00C2F766 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		00371A0127EE588C00C2F766 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		00371A2227F02B1900C2F766 /* CentralView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CentralView.swift; sourceTree = "<group>"; };
 		EB443F8E27C6BCA70005CCEA /* CombineCoreBluetooth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CombineCoreBluetooth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB443F9927C6BDE00005CCEA /* CombineCoreBluetooth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CombineCoreBluetooth.h; sourceTree = "<group>"; };
 		EB443F9C27C6BDE00005CCEA /* Exports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exports.swift; sourceTree = "<group>"; };
@@ -77,6 +90,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		003719F527EE588900C2F766 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0014FFB227F0359600D2A122 /* CombineCoreBluetooth in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EB443F8B27C6BCA70005CCEA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -95,11 +116,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		003719F927EE588900C2F766 /* CentralPeripheralDemo */ = {
+			isa = PBXGroup;
+			children = (
+				0014FFB027F032C000D2A122 /* Info.plist */,
+				003719FA27EE588900C2F766 /* PeripheralDemoApp.swift */,
+				00371A2227F02B1900C2F766 /* CentralView.swift */,
+				003719FC27EE588900C2F766 /* PeripheralView.swift */,
+				003719FE27EE588C00C2F766 /* Assets.xcassets */,
+				00371A0027EE588C00C2F766 /* Preview Content */,
+			);
+			path = CentralPeripheralDemo;
+			sourceTree = "<group>";
+		};
+		00371A0027EE588C00C2F766 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				00371A0127EE588C00C2F766 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		EB443F8427C6BCA70005CCEA = {
 			isa = PBXGroup;
 			children = (
 				EB443F9827C6BDE00005CCEA /* Sources */,
 				EB443FE327C6C1B40005CCEA /* Tests */,
+				003719F927EE588900C2F766 /* CentralPeripheralDemo */,
 				EB443F8F27C6BCA70005CCEA /* Products */,
 				EB443FD027C6BE440005CCEA /* Frameworks */,
 			);
@@ -110,6 +153,7 @@
 			children = (
 				EB443F8E27C6BCA70005CCEA /* CombineCoreBluetooth.framework */,
 				EB443FD927C6C1940005CCEA /* CombineCoreBluetooth Tests.xctest */,
+				003719F827EE588900C2F766 /* CentralPeripheralDemo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -239,6 +283,26 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		003719F727EE588900C2F766 /* CentralPeripheralDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 00371A0527EE588C00C2F766 /* Build configuration list for PBXNativeTarget "CentralPeripheralDemo" */;
+			buildPhases = (
+				003719F427EE588900C2F766 /* Sources */,
+				003719F527EE588900C2F766 /* Frameworks */,
+				003719F627EE588900C2F766 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CentralPeripheralDemo;
+			packageProductDependencies = (
+				0014FFB127F0359600D2A122 /* CombineCoreBluetooth */,
+			);
+			productName = PeripheralDemo;
+			productReference = 003719F827EE588900C2F766 /* CentralPeripheralDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 		EB443F8D27C6BCA70005CCEA /* CombineCoreBluetooth */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EB443F9527C6BCA70005CCEA /* Build configuration list for PBXNativeTarget "CombineCoreBluetooth" */;
@@ -282,9 +346,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
+					003719F727EE588900C2F766 = {
+						CreatedOnToolsVersion = 13.3;
+					};
 					EB443F8D27C6BCA70005CCEA = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
@@ -308,11 +375,21 @@
 			targets = (
 				EB443F8D27C6BCA70005CCEA /* CombineCoreBluetooth */,
 				EB443FD827C6C1940005CCEA /* CombineCoreBluetooth Tests */,
+				003719F727EE588900C2F766 /* CentralPeripheralDemo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		003719F627EE588900C2F766 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				00371A0227EE588C00C2F766 /* Preview Assets.xcassets in Resources */,
+				003719FF27EE588C00C2F766 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EB443F8C27C6BCA70005CCEA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -330,6 +407,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		003719F427EE588900C2F766 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				00371A2327F02B1900C2F766 /* CentralView.swift in Sources */,
+				003719FD27EE588900C2F766 /* PeripheralView.swift in Sources */,
+				003719FB27EE588900C2F766 /* PeripheralDemoApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EB443F8A27C6BCA70005CCEA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -379,6 +466,78 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		00371A0327EE588C00C2F766 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"CentralPeripheralDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = AZKV6YHQQR;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CentralPeripheralDemo/Info.plist;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Uses bluetooth for testing purposes";
+				INFOPLIST_KEY_NSBluetoothPeripheralUsageDescription = "Behaves as a bluetooth peripheral for testing purposes";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.starry.CentralPeripheralDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+			};
+			name = Debug;
+		};
+		00371A0427EE588C00C2F766 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"CentralPeripheralDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = AZKV6YHQQR;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CentralPeripheralDemo/Info.plist;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Uses bluetooth for testing purposes";
+				INFOPLIST_KEY_NSBluetoothPeripheralUsageDescription = "Behaves as a bluetooth peripheral for testing purposes";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.starry.CentralPeripheralDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
+			};
+			name = Release;
+		};
 		EB443F9327C6BCA70005CCEA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -602,6 +761,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		00371A0527EE588C00C2F766 /* Build configuration list for PBXNativeTarget "CentralPeripheralDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				00371A0327EE588C00C2F766 /* Debug */,
+				00371A0427EE588C00C2F766 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		EB443F8827C6BCA70005CCEA /* Build configuration list for PBXProject "CombineCoreBluetooth" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -630,6 +798,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0014FFB127F0359600D2A122 /* CombineCoreBluetooth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CombineCoreBluetooth;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = EB443F8527C6BCA70005CCEA /* Project object */;
 }

--- a/Sources/CombineCoreBluetooth/Internal/Publisher+Extensions.swift
+++ b/Sources/CombineCoreBluetooth/Internal/Publisher+Extensions.swift
@@ -23,8 +23,7 @@ extension Publisher {
 
   /// Applies the predicate to the first item in the Output's tuple; if it matches, take the first element from that and pass it along or throw any errors that are present.
   func filterFirstValueOrThrow<Value>(where predicate: @escaping (Value, Error?) -> Bool) -> AnyPublisher<Value, Error> where Output == (Value, Error?) {
-    filter(predicate)
-      .first()
+    first(where: predicate)
       .tryMap { value, error in
         if let error = error { throw error }
         return value

--- a/Sources/CombineCoreBluetooth/Models/PeripheralDiscovery.swift
+++ b/Sources/CombineCoreBluetooth/Models/PeripheralDiscovery.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PeripheralDiscovery {
+public struct PeripheralDiscovery: Identifiable {
   public let peripheral: Peripheral
   public let advertisementData: AdvertisementData
   public let rssi: Double?
@@ -9,5 +9,9 @@ public struct PeripheralDiscovery {
     self.peripheral = peripheral
     self.advertisementData = advertisementData
     self.rssi = rssi
+  }
+
+  public var id: UUID {
+    peripheral.id
   }
 }

--- a/Sources/CombineCoreBluetooth/Peripheral/Convenience+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Convenience+Peripheral.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreBluetooth
 
 public enum PeripheralError: Error, Equatable {
   case serviceNotFound(CBUUID)
@@ -55,6 +56,15 @@ extension Peripheral {
         self.readValue(for: characteristic)
       }
       .map(\.value)
+      .eraseToAnyPublisher()
+  }
+
+  public func writeValue(_ value: Data, writeType: CBCharacteristicWriteType, forCharacteristic characteristicUUID: CBUUID, inService serviceUUID: CBUUID) -> AnyPublisher<Void, Error> {
+    discoverCharacteristic(withUUID: characteristicUUID, inServiceWithUUID: serviceUUID)
+      .flatMap { characteristic in
+        self.writeValue(value, for: characteristic, type: writeType)
+      }
+      .map { _ in }
       .eraseToAnyPublisher()
   }
 }


### PR DESCRIPTION
This will allow for a more expected publisher lifecycle with regards to writing to characteristics. If you use the `.withoutResponse` write type, an empty publisher is returned that will end immediately after subscribing to it (though it's still necessary to subscribe to it to kick off the write). 

This also includes a demo application to test various scenarios of writing to characteristics with different write types and different write properties/permissions.

