### PR TITLE
Return an error when trying to write without response to a characteristic that doesnt support it.

### DIFF
--- a/CentralPeripheralDemo/CentralView.swift
+++ b/CentralPeripheralDemo/CentralView.swift
@@ -119,7 +119,9 @@ struct CentralView: View {
           if let error = demo.connectError {
             Text("Error: \(String(describing: error))")
           }
+        }
 
+        Section("Discovered peripherals") {
           ForEach(demo.peripherals) { discovery in
             Button(discovery.peripheral.name ?? "<nil>") {
               demo.connect(discovery)
@@ -217,7 +219,11 @@ struct PeripheralDeviceView: View {
       case let .success(value)?:
         Text("Wrote at \(String(describing: value))")
       case let .failure(error)?:
-        Text("Error: \(String(describing: error))")
+        if let error = error as? LocalizedError, let errorDescription = error.errorDescription {
+          Text("Error: \(errorDescription)")
+        } else {
+          Text("Error: \(String(describing: error))")
+        }
       case nil:
         EmptyView()
       }


### PR DESCRIPTION
Core Bluetooth will silently throw away any writes you attempt to make to a characteristic if you try to use the `withoutResponse` write type, and the characteristic you're writing to only supports the `withResponse` write type. The only indication that anything goes wrong here will be a log to the central device's console.

If we try to write without response to an unsupported characteristic, fail the returned publisher with a descriptive error instead.