### PR TITLE
bugfix: Keep reference to CBL2CAPChannel so the system doesn't close it

### DIFF
--- a/Sources/CombineCoreBluetooth/Models/L2CAPChannel.swift
+++ b/Sources/CombineCoreBluetooth/Models/L2CAPChannel.swift
@@ -3,7 +3,7 @@ import CoreBluetooth
 
 public struct L2CAPChannel {
   // Need to keep a reference to this so the system doesn't close the channel
-  let rawValue: CBL2CAPChannel
+  let rawValue: CBL2CAPChannel?
   public let peer: Peer
   public let inputStream: InputStream
   public let outputStream: OutputStream


### PR DESCRIPTION
I found that at least on iOS (15.3), the system will immediately close an L2CAP channel if no reference is kept to the `CBL2CAPChannel` object.