### PR TITLE
Add new helper methods to Peripheral and PeripheralManager

### DIFF
--- a/CombineCoreBluetooth.xcodeproj/project.pbxproj
+++ b/CombineCoreBluetooth.xcodeproj/project.pbxproj
@@ -213,8 +213,8 @@
 			isa = PBXGroup;
 			children = (
 				EB443FA727C6BDE00005CCEA /* Interface+PeripheralManager.swift */,
-				EB443FA827C6BDE00005CCEA /* Mock+PeripheralManager.swift */,
 				EB443FA927C6BDE00005CCEA /* Live+PeripheralManager.swift */,
+				EB443FA827C6BDE00005CCEA /* Mock+PeripheralManager.swift */,
 			);
 			path = PeripheralManager;
 			sourceTree = "<group>";
@@ -222,9 +222,9 @@
 		EB443FAA27C6BDE00005CCEA /* Peripheral */ = {
 			isa = PBXGroup;
 			children = (
-				EB443FAB27C6BDE00005CCEA /* Mock+Peripheral.swift */,
 				EB443FAC27C6BDE00005CCEA /* Interface+Peripheral.swift */,
 				EB443FAD27C6BDE00005CCEA /* Live+Peripheral.swift */,
+				EB443FAB27C6BDE00005CCEA /* Mock+Peripheral.swift */,
 			);
 			path = Peripheral;
 			sourceTree = "<group>";
@@ -232,9 +232,9 @@
 		EB443FAF27C6BDE00005CCEA /* Central */ = {
 			isa = PBXGroup;
 			children = (
-				EB443FB027C6BDE00005CCEA /* Mock+Central.swift */,
-				EB443FB127C6BDE00005CCEA /* Live+Central.swift */,
 				EB443FB227C6BDE00005CCEA /* Interface+Central.swift */,
+				EB443FB127C6BDE00005CCEA /* Live+Central.swift */,
+				EB443FB027C6BDE00005CCEA /* Mock+Central.swift */,
 			);
 			path = Central;
 			sourceTree = "<group>";
@@ -242,8 +242,8 @@
 		EB443FB327C6BDE00005CCEA /* CentralManager */ = {
 			isa = PBXGroup;
 			children = (
-				EB443FB427C6BDE00005CCEA /* Live+CentralManager.swift */,
 				EB443FB527C6BDE00005CCEA /* Interface+CentralManager.swift */,
+				EB443FB427C6BDE00005CCEA /* Live+CentralManager.swift */,
 				EB443FB627C6BDE00005CCEA /* Mock+CentralManager.swift */,
 			);
 			path = CentralManager;

--- a/CombineCoreBluetooth.xcodeproj/project.pbxproj
+++ b/CombineCoreBluetooth.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		00371A2327F02B1900C2F766 /* CentralView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00371A2227F02B1900C2F766 /* CentralView.swift */; };
 		00482BE828308A4D0053B7C1 /* PeripheralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00482BE728308A4D0053B7C1 /* PeripheralTests.swift */; };
 		00CF0B78288DD73700FD88E1 /* PeripheralError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CF0B77288DD73700FD88E1 /* PeripheralError.swift */; };
+		00D8C7432A69A6E20069EC00 /* PeripheralManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D8C7422A69A6E20069EC00 /* PeripheralManagerError.swift */; };
 		EB443FB927C6BDE10005CCEA /* Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443F9C27C6BDE00005CCEA /* Exports.swift */; };
 		EB443FBA27C6BDE10005CCEA /* PassthroughBacked.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443F9D27C6BDE00005CCEA /* PassthroughBacked.swift */; };
 		EB443FBB27C6BDE10005CCEA /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443F9E27C6BDE00005CCEA /* Publisher+Extensions.swift */; };
@@ -62,6 +63,7 @@
 		00371A2227F02B1900C2F766 /* CentralView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CentralView.swift; sourceTree = "<group>"; };
 		00482BE728308A4D0053B7C1 /* PeripheralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralTests.swift; sourceTree = "<group>"; };
 		00CF0B77288DD73700FD88E1 /* PeripheralError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralError.swift; sourceTree = "<group>"; };
+		00D8C7422A69A6E20069EC00 /* PeripheralManagerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeripheralManagerError.swift; sourceTree = "<group>"; };
 		EB443F8E27C6BCA70005CCEA /* CombineCoreBluetooth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CombineCoreBluetooth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB443F9927C6BDE00005CCEA /* CombineCoreBluetooth.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CombineCoreBluetooth.h; sourceTree = "<group>"; };
 		EB443F9C27C6BDE00005CCEA /* Exports.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exports.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				EB443FA527C6BDE00005CCEA /* Peer.swift */,
 				EB443FA427C6BDE00005CCEA /* PeripheralDiscovery.swift */,
 				00CF0B77288DD73700FD88E1 /* PeripheralError.swift */,
+				00D8C7422A69A6E20069EC00 /* PeripheralManagerError.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -434,6 +437,7 @@
 				EB443FC027C6BDE10005CCEA /* PeripheralDiscovery.swift in Sources */,
 				EB443FBA27C6BDE10005CCEA /* PassthroughBacked.swift in Sources */,
 				EB443FCA27C6BDE10005CCEA /* Live+Central.swift in Sources */,
+				00D8C7432A69A6E20069EC00 /* PeripheralManagerError.swift in Sources */,
 				EB443FC727C6BDE10005CCEA /* Live+Peripheral.swift in Sources */,
 				EB443FBE27C6BDE10005CCEA /* ATTRequest.swift in Sources */,
 				EB443FBC27C6BDE10005CCEA /* Unimplemented.swift in Sources */,

--- a/Sources/CombineCoreBluetooth/Internal/Publisher+Extensions.swift
+++ b/Sources/CombineCoreBluetooth/Internal/Publisher+Extensions.swift
@@ -24,7 +24,6 @@ extension Publisher {
   func filterFirstValueOrThrow<Value>(where predicate: @escaping (Value, Error?) -> Bool) -> AnyPublisher<Value, Error> where Output == (Value, Error?) {
     first(where: predicate)
       .selectValueOrThrowError()
-      .eraseToAnyPublisher()
   }
 
   func selectValueOrThrowError<Value>() -> AnyPublisher<Value, Error> where Output == (Value, Error?) {
@@ -35,5 +34,9 @@ extension Publisher {
       return value
     }
     .eraseToAnyPublisher()
+  }
+  
+  func setOutputType<T>(to type: T.Type) -> Publishers.Map<Self, T> where Output == Never {
+    map { _ -> T in }
   }
 }

--- a/Sources/CombineCoreBluetooth/Models/PeripheralError.swift
+++ b/Sources/CombineCoreBluetooth/Models/PeripheralError.swift
@@ -4,4 +4,5 @@ import CoreBluetooth
 public enum PeripheralError: Error, Equatable {
   case serviceNotFound(CBUUID)
   case characteristicNotFound(CBUUID)
+  case descriptorNotFound(CBUUID, onCharacteristic: CBUUID)
 }

--- a/Sources/CombineCoreBluetooth/Models/PeripheralManagerError.swift
+++ b/Sources/CombineCoreBluetooth/Models/PeripheralManagerError.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum PeripheralManagerError: Error, Equatable {
+  /// Thrown if there's a failure during connection to a peripheral
+  case failedToUpdateCharacteristic(CBUUID)
+}

--- a/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
@@ -80,7 +80,6 @@ public struct Peripheral {
         _readRSSI()
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func discoverServices(_ serviceUUIDs: [CBUUID]?) -> AnyPublisher<[CBService], Error> {
@@ -98,7 +97,6 @@ public struct Peripheral {
         _discoverServices(serviceUUIDs)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func discoverIncludedServices(_ serviceUUIDS: [CBUUID]?, for service: CBService) -> AnyPublisher<[CBService]?, Error> {
@@ -119,7 +117,6 @@ public struct Peripheral {
         _discoverIncludedServices(serviceUUIDS, service)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBService) -> AnyPublisher<[CBCharacteristic], Error> {
@@ -140,7 +137,6 @@ public struct Peripheral {
         _discoverCharacteristics(characteristicUUIDs, service)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func readValue(for characteristic: CBCharacteristic) -> AnyPublisher<Data?, Error> {
@@ -153,7 +149,6 @@ public struct Peripheral {
         _readValueForCharacteristic(characteristic)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func maximumWriteValueLength(for writeType: CBCharacteristicWriteType) -> Int {
@@ -202,7 +197,6 @@ public struct Peripheral {
        _writeValueForCharacteristic(value, characteristic, .withResponse)
      })
      .shareCurrentValue()
-     .eraseToAnyPublisher()
   }
 
   public func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic) -> AnyPublisher<Void, Error> {
@@ -215,7 +209,6 @@ public struct Peripheral {
         _setNotifyValue(enabled, characteristic)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func discoverDescriptors(for characteristic: CBCharacteristic) -> AnyPublisher<[CBDescriptor]?, Error> {
@@ -228,7 +221,6 @@ public struct Peripheral {
         _discoverDescriptors(characteristic)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func readValue(for descriptor: CBDescriptor) -> AnyPublisher<Any?, Error> {
@@ -241,7 +233,6 @@ public struct Peripheral {
         _readValueForDescriptor(descriptor)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func writeValue(_ value: Data, for descriptor: CBDescriptor) -> AnyPublisher<Void, Error> {
@@ -254,7 +245,6 @@ public struct Peripheral {
         _writeValueForDescriptor(value, descriptor)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   public func openL2CAPChannel(_ psm: CBL2CAPPSM) -> AnyPublisher<L2CAPChannel, Error> {
@@ -268,7 +258,6 @@ public struct Peripheral {
         _openL2CAPChannel(psm)
       })
       .shareCurrentValue()
-      .eraseToAnyPublisher()
   }
 
   // MARK: - Convenience methods
@@ -339,6 +328,9 @@ public struct Peripheral {
   }
 
   /// Returns a long-lived publisher that receives all value updates for the given characteristic. Allows for many listeners to be updated for a single read, or for indications/notifications of a characteristic.
+  ///
+  /// This function does not subscribe to notifications or indications on its own.
+  ///
   /// - Parameter characteristic: The characteristic to listen to for updates.
   /// - Returns: A publisher that will listen to updates to the given characteristic. Continues indefinitely, unless an error is encountered.
   public func listenForUpdates(on characteristic: CBCharacteristic) -> AnyPublisher<Data?, Error> {
@@ -347,11 +339,36 @@ public struct Peripheral {
       .filter({ (readCharacteristic, error) -> Bool in
         return readCharacteristic.uuid == characteristic.uuid
       })
-      .tryMap {
-        if let error = $1 { throw error }
-        return $0.value
-      }
+      .selectValueOrThrowError()
+      .map(\.value)
       .eraseToAnyPublisher()
+  }
+  
+  /// Subscribes to an update on the given characteristic, and if subscription succeeds, the returned publisher receives all updates to that characteristic until the subscriptions to this publisher are cancelled.
+  ///
+  /// If the characteristic doesn't support notifications or indications, the publisher will fail with an error.
+  /// - Parameter characteristic: The characteristic to subscribe to
+  /// - Returns: A publisher that is sent updates to the given characteristic's value.
+  public func subscribeToUpdates(on characteristic: CBCharacteristic) -> AnyPublisher<Data?, Error> {
+    Publishers.Merge(
+      self.listenForUpdates(on: characteristic),
+      
+      didUpdateNotificationState
+        .filterFirstValueOrThrow(where: {
+          $0.uuid == characteristic.uuid
+        })
+        .ignoreOutput()
+        .setOutputType(to: Data?.self)
+    )
+    .handleEvents(
+      receiveSubscription: { _ in
+        _setNotifyValue(true, characteristic)
+      },
+      receiveCancel: {
+        _setNotifyValue(false, characteristic)
+      }
+    )
+    .shareCurrentValue()
   }
 }
 

--- a/Tests/CombineCoreBluetoothTests/PeripheralManagerTests.swift
+++ b/Tests/CombineCoreBluetoothTests/PeripheralManagerTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import CombineCoreBluetooth
+
+final class PeripheralManagerTests: XCTestCase {
+  
+  var cancellables: Set<AnyCancellable>!
+  
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    cancellables = []
+  }
+  
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    cancellables = nil
+  }
+  
+  func testUpdateValueSuccessCase() throws {
+    let characteristic = CBMutableCharacteristic(type: .init(string: "0001"), properties: [.notify], value: nil, permissions: [.readable])
+    let central = Central.unimplemented(identifier: .init(), maximumUpdateValueLength: { 512 })
+    let peripheralManager = PeripheralManager.unimplemented(
+      updateValueForCharacteristic: { _, _, _ in true },
+      readyToUpdateSubscribers: Just(()).eraseToAnyPublisher()
+    )
+    
+    peripheralManager.updateValue(Data(), for: characteristic, onSubscribedCentrals: [central])
+      .sink { c in
+        if case let .failure(error) = c {
+          XCTFail("Unexpected error: \(error)")
+        }
+      } receiveValue: { _ in
+        
+      }.store(in: &cancellables)
+  }
+  
+  func testUpdateValueErrorCase() throws {
+    let characteristic = CBMutableCharacteristic(type: .init(string: "0001"), properties: [.notify], value: nil, permissions: [.readable])
+    let central = Central.unimplemented(identifier: .init(), maximumUpdateValueLength: { 512 })
+    let readyToUpdateSubject = PassthroughSubject<Void, Never>()
+    let peripheralManager = PeripheralManager.unimplemented(
+      updateValueForCharacteristic: { _, _, _ in false },
+      readyToUpdateSubscribers: readyToUpdateSubject.eraseToAnyPublisher()
+    )
+    
+    var complete = false
+    peripheralManager.updateValue(Data(), for: characteristic, onSubscribedCentrals: [central])
+      .sink { c in
+        complete = true
+        if case .finished = c {
+          XCTFail("Expected an error to be thrown if updating fails after the builtin retry count")
+        }
+      } receiveValue: { _ in
+        
+      }.store(in: &cancellables)
+    
+    for _ in 1...4 {
+      readyToUpdateSubject.send(())
+    }
+    XCTAssert(complete)
+  }
+  
+  
+  func testUpdateValueSucceedsAfter4Retries() throws {
+    let characteristic = CBMutableCharacteristic(type: .init(string: "0001"), properties: [.notify], value: nil, permissions: [.readable])
+    let central = Central.unimplemented(identifier: .init(), maximumUpdateValueLength: { 512 })
+    let readyToUpdateSubject = PassthroughSubject<Void, Never>()
+    var shouldSucceed = false
+    let peripheralManager = PeripheralManager.unimplemented(
+      updateValueForCharacteristic: { _, _, _ in shouldSucceed },
+      readyToUpdateSubscribers: readyToUpdateSubject.eraseToAnyPublisher()
+    )
+    
+    var complete = false
+    peripheralManager.updateValue(Data(), for: characteristic, onSubscribedCentrals: [central])
+      .sink { c in
+        complete = true
+        if case let .failure(error) = c {
+          XCTFail("Unexpected error: \(error)")
+        }
+      } receiveValue: { _ in
+        
+      }
+      .store(in: &cancellables)
+    
+    for _ in 1...3 {
+      readyToUpdateSubject.send(())
+    }
+    shouldSucceed = true
+    readyToUpdateSubject.send(())
+    XCTAssert(complete)
+  }
+}


### PR DESCRIPTION
- Add `subscribeToUpdates` method to `Peripheral` that subscribes to updates, sends those updates through the publisher, and unsubscribes when the subscription is cancelled.
- Add logic to `updateValue(_:for:onSubscribedCentrals:)` on `PeripheralManager` to automatically wait for the central to be ready for updates again, and to retry up to 4 extra times to send the update.
