### PR TITLE
Modify PeripheralManager API to use more publishers where it makes sense

### DIFF
--- a/CentralPeripheralDemo/PeripheralView.swift
+++ b/CentralPeripheralDemo/PeripheralView.swift
@@ -31,7 +31,8 @@ class PeripheralDemo: ObservableObject {
         }).joined(separator: "\n"), to: &self.logs)
 
         self.peripheralManager.respond(to: requests[0], withResult: .success)
-      }.store(in: &cancellables)
+      }
+      .store(in: &cancellables)
   }
 
   func buildServices() {
@@ -65,20 +66,15 @@ class PeripheralDemo: ObservableObject {
   }
 
   func start() {
-    if peripheralManager.state == .poweredOn {
-      buildServices()
-      peripheralManager.startAdvertising(.init([.serviceUUIDs: [CBUUID.service]]))
-      advertising = true
-    } else {
-      // once bt is powered on, advertise
-      peripheralManager.didUpdateState
-        .first(where: { $0 == .poweredOn })
-        .receive(on: DispatchQueue.main)
-        .sink { [weak self] _ in
-          self?.start()
-        }
-        .store(in: &cancellables)
-    }
+    buildServices()
+      
+    peripheralManager.startAdvertising(.init([.serviceUUIDs: [CBUUID.service]]))
+      .sink(receiveCompletion: { c in
+        
+      }, receiveValue: { [weak self] _ in
+        self?.advertising = true
+      })
+      .store(in: &cancellables)
   }
 
   func stop() {

--- a/CombineCoreBluetooth.xcodeproj/project.pbxproj
+++ b/CombineCoreBluetooth.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		EB443FCE27C6BDE10005CCEA /* Mock+CentralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443FB627C6BDE00005CCEA /* Mock+CentralManager.swift */; };
 		EB443FDD27C6C1940005CCEA /* CombineCoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB443F8E27C6BCA70005CCEA /* CombineCoreBluetooth.framework */; };
 		EB443FE627C6C1B40005CCEA /* CentralManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB443FE527C6C1B40005CCEA /* CentralManagerTests.swift */; };
+		ED2D6EAF2A6A159D008BD1A2 /* PeripheralManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2D6EAE2A6A159D008BD1A2 /* PeripheralManagerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		EB443FD327C6BE5A0005CCEA /* Combine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Combine.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/System/Library/Frameworks/Combine.framework; sourceTree = DEVELOPER_DIR; };
 		EB443FD927C6C1940005CCEA /* CombineCoreBluetooth Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CombineCoreBluetooth Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB443FE527C6C1B40005CCEA /* CentralManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CentralManagerTests.swift; sourceTree = "<group>"; };
+		ED2D6EAE2A6A159D008BD1A2 /* PeripheralManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeripheralManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -273,6 +275,7 @@
 			isa = PBXGroup;
 			children = (
 				EB443FE527C6C1B40005CCEA /* CentralManagerTests.swift */,
+				ED2D6EAE2A6A159D008BD1A2 /* PeripheralManagerTests.swift */,
 				00482BE728308A4D0053B7C1 /* PeripheralTests.swift */,
 			);
 			path = CombineCoreBluetoothTests;
@@ -462,6 +465,7 @@
 			files = (
 				EB443FE627C6C1B40005CCEA /* CentralManagerTests.swift in Sources */,
 				00482BE828308A4D0053B7C1 /* PeripheralTests.swift in Sources */,
+				ED2D6EAF2A6A159D008BD1A2 /* PeripheralManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/CombineCoreBluetooth/Internal/Publisher+Extensions.swift
+++ b/Sources/CombineCoreBluetooth/Internal/Publisher+Extensions.swift
@@ -36,7 +36,7 @@ extension Publisher {
     .eraseToAnyPublisher()
   }
   
-  func setOutputType<T>(to type: T.Type) -> Publishers.Map<Self, T> where Output == Never {
-    map { _ -> T in }
+  func ignoreOutput<NewOutput>(setOutputType newOutputType: NewOutput.Type) -> Publishers.Map<Publishers.IgnoreOutput<Self>, NewOutput> {
+    ignoreOutput().map { _ -> NewOutput in }
   }
 }

--- a/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
@@ -440,8 +440,7 @@ public struct Peripheral {
         .filterFirstValueOrThrow(where: {
           $0.uuid == characteristic.uuid
         })
-        .ignoreOutput()
-        .setOutputType(to: Data?.self)
+        .ignoreOutput(setOutputType: Data?.self)
     )
     .handleEvents(
       receiveSubscription: { _ in

--- a/Tests/CombineCoreBluetoothTests/PeripheralManagerTests.swift
+++ b/Tests/CombineCoreBluetoothTests/PeripheralManagerTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import CombineCoreBluetooth
 
 final class PeripheralManagerTests: XCTestCase {
-  
   var cancellables: Set<AnyCancellable>!
   
   override func setUpWithError() throws {


### PR DESCRIPTION
This fixes #10.

- startAdvertising(_:) now will check if bluetooth is powered on before continuing; if it isn't, it waits for that state change first, then starts advertising, and the returned publisher will send whether didStartAdvertising returned an error or not

- publishL2CAPChannel and unpublishL2CAPChannel now return publishers that listen to the delegate publishers and return the resulting PSM, or an error if one occurred for each command.
