### PR TITLE
Add tvos/watchos build/tests, bump macos version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           set -o pipefail && xcodebuild \
            -scheme CombineCoreBluetooth \
            -workspace ./CombineCoreBluetooth.xcworkspace/ \
-           -destination "platform=tvOS Simulator,OS=16.2,name=Apple TV" \
+           -destination "platform=tvOS Simulator,OS=16.1,name=Apple TV" \
            -sdk appletvsimulator \
            -enableCodeCoverage YES \
            -disableAutomaticPackageResolution \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,15 @@ on:
       - "**.podspec"
       - ".github/workflows/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-mac:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         run: swift build --build-tests
       - name: Run tests
@@ -29,12 +33,46 @@ jobs:
         run: carthage build --no-skip-current --verbose --use-xcframeworks --platform macOS
 
   build-ios:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
+      - uses: actions/checkout@v3
+      - name: Test
         run: |
-          swift build -Xswiftc "-sdk" \
-           -Xswiftc `xcrun --sdk iphonesimulator --show-sdk-path` \
-           -Xswiftc "-target" \
-           -Xswiftc "x86_64-apple-ios`xcrun --show-sdk-version --sdk iphonesimulator`-simulator"
+          set -o pipefail && xcodebuild \
+           -scheme CombineCoreBluetooth \
+           -workspace ./CombineCoreBluetooth.xcworkspace/ \
+           -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14" \
+           -sdk iphonesimulator \
+           -enableCodeCoverage YES \
+           -disableAutomaticPackageResolution \
+           test | xcpretty -c
+
+  build-tvos:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test
+        run: |
+          set -o pipefail && xcodebuild \
+           -scheme CombineCoreBluetooth \
+           -workspace ./CombineCoreBluetooth.xcworkspace/ \
+           -destination "platform=tvOS Simulator,OS=16.2,name=Apple TV" \
+           -sdk appletvsimulator \
+           -enableCodeCoverage YES \
+           -disableAutomaticPackageResolution \
+           test | xcpretty -c
+
+  build-watchos:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test
+        run: |
+          set -o pipefail && xcodebuild \
+           -scheme CombineCoreBluetooth \
+           -workspace ./CombineCoreBluetooth.xcworkspace/ \
+           -destination "platform=watchOS Simulator,OS=9.1,name=Apple Watch Ultra (49mm)" \
+           -sdk watchsimulator \
+           -enableCodeCoverage YES \
+           -disableAutomaticPackageResolution \
+           test | xcpretty -c

--- a/CombineCoreBluetooth.xcodeproj/xcshareddata/xcschemes/CentralPeripheralDemo.xcscheme
+++ b/CombineCoreBluetooth.xcodeproj/xcshareddata/xcschemes/CentralPeripheralDemo.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "003719F727EE588900C2F766"
+               BuildableName = "CentralPeripheralDemo.app"
+               BlueprintName = "CentralPeripheralDemo"
+               ReferencedContainer = "container:CombineCoreBluetooth.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "003719F727EE588900C2F766"
+            BuildableName = "CentralPeripheralDemo.app"
+            BlueprintName = "CentralPeripheralDemo"
+            ReferencedContainer = "container:CombineCoreBluetooth.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "003719F727EE588900C2F766"
+            BuildableName = "CentralPeripheralDemo.app"
+            BlueprintName = "CentralPeripheralDemo"
+            ReferencedContainer = "container:CombineCoreBluetooth.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/CombineCoreBluetoothTests/PeripheralManagerTests.swift
+++ b/Tests/CombineCoreBluetoothTests/PeripheralManagerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import CombineCoreBluetooth
 
+#if !os(watchOS) && !os(tvOS)
 final class PeripheralManagerTests: XCTestCase {
   var cancellables: Set<AnyCancellable>!
   
@@ -16,6 +17,7 @@ final class PeripheralManagerTests: XCTestCase {
   
   func testUpdateValueSuccessCase() throws {
     let characteristic = CBMutableCharacteristic(type: .init(string: "0001"), properties: [.notify], value: nil, permissions: [.readable])
+
     let central = Central.unimplemented(identifier: .init(), maximumUpdateValueLength: { 512 })
     let peripheralManager = PeripheralManager.unimplemented(
       updateValueForCharacteristic: { _, _, _ in true },
@@ -89,3 +91,4 @@ final class PeripheralManagerTests: XCTestCase {
     XCTAssert(complete)
   }
 }
+#endif

--- a/Tests/CombineCoreBluetoothTests/PeripheralTests.swift
+++ b/Tests/CombineCoreBluetoothTests/PeripheralTests.swift
@@ -8,6 +8,7 @@
 @testable import CombineCoreBluetooth
 import XCTest
 
+#if !os(watchOS) && !os(tvOS)
 class PeripheralTests: XCTestCase {
 
   override func setUpWithError() throws {
@@ -406,3 +407,4 @@ extension Peripheral {
     )
   }
 }
+#endif


### PR DESCRIPTION
Disable some test classes so that they dont compile for watchos/tvos, as they rely on creating services/characteristics that cannot happen on those platforms.