### PR TITLE
Make more properties mutable on the main types

### DIFF
--- a/Sources/CombineCoreBluetooth/Central/Interface+Central.swift
+++ b/Sources/CombineCoreBluetooth/Central/Interface+Central.swift
@@ -6,7 +6,7 @@ public struct Central: Sendable {
 
   public let identifier: UUID
 
-  let _maximumUpdateValueLength: @Sendable () -> Int
+  public var _maximumUpdateValueLength: @Sendable () -> Int
 
   public var maximumUpdateValueLength: Int {
     _maximumUpdateValueLength()

--- a/Sources/CombineCoreBluetooth/CentralManager/Interface+CentralManager.swift
+++ b/Sources/CombineCoreBluetooth/CentralManager/Interface+CentralManager.swift
@@ -8,32 +8,32 @@ public struct CentralManager: Sendable {
   public typealias Feature = CBCentralManager.Feature
 #endif
   let delegate: Delegate?
+
+  public var _state: @Sendable () -> CBManagerState
+  public var _authorization: @Sendable () -> CBManagerAuthorization
+  public var _isScanning: @Sendable () -> Bool
+
+  public var _supportsFeatures: @Sendable (_ feature: Feature) -> Bool
+
+  public var _retrievePeripheralsWithIdentifiers: @Sendable ([UUID]) -> [Peripheral]
+  public var _retrieveConnectedPeripheralsWithServices: @Sendable ([CBUUID]) -> [Peripheral]
+  public var _scanForPeripheralsWithServices: @Sendable (_  serviceUUIDs: [CBUUID]?, _ options: ScanOptions?) -> Void
+  public var _stopScan: @Sendable () -> Void
+
+  public var _connectToPeripheral: @Sendable (Peripheral, _ options: PeripheralConnectionOptions?) -> Void
+  public var _cancelPeripheralConnection: @Sendable (_ peripheral: Peripheral) -> Void
+  public var _registerForConnectionEvents: @Sendable (_ options: [CBConnectionEventMatchingOption : Any]?) -> Void
   
-  let _state: @Sendable () -> CBManagerState
-  let _authorization: @Sendable () -> CBManagerAuthorization
-  let _isScanning: @Sendable () -> Bool
+  public var didUpdateState: AnyPublisher<CBManagerState, Never>
+  public var willRestoreState: AnyPublisher<[String: Any], Never>
+  public var didConnectPeripheral: AnyPublisher<Peripheral, Never>
+  public var didFailToConnectPeripheral: AnyPublisher<(Peripheral, Error?), Never>
+  public var didDisconnectPeripheral: AnyPublisher<(Peripheral, Error?), Never>
   
-  let _supportsFeatures: @Sendable (_ feature: Feature) -> Bool
+  public var connectionEventDidOccur: AnyPublisher<(CBConnectionEvent, Peripheral), Never>
+  public var didDiscoverPeripheral: AnyPublisher<PeripheralDiscovery, Never>
   
-  let _retrievePeripheralsWithIdentifiers: @Sendable ([UUID]) -> [Peripheral]
-  let _retrieveConnectedPeripheralsWithServices: @Sendable ([CBUUID]) -> [Peripheral]
-  let _scanForPeripheralsWithServices: @Sendable (_  serviceUUIDs: [CBUUID]?, _ options: ScanOptions?) -> Void
-  let _stopScan: @Sendable () -> Void
-  
-  let _connectToPeripheral: @Sendable (Peripheral, _ options: PeripheralConnectionOptions?) -> Void
-  let _cancelPeripheralConnection: @Sendable (_ peripheral: Peripheral) -> Void
-  let _registerForConnectionEvents: @Sendable (_ options: [CBConnectionEventMatchingOption : Any]?) -> Void
-  
-  public let didUpdateState: AnyPublisher<CBManagerState, Never>
-  public let willRestoreState: AnyPublisher<[String: Any], Never>
-  public let didConnectPeripheral: AnyPublisher<Peripheral, Never>
-  public let didFailToConnectPeripheral: AnyPublisher<(Peripheral, Error?), Never>
-  public let didDisconnectPeripheral: AnyPublisher<(Peripheral, Error?), Never>
-  
-  public let connectionEventDidOccur: AnyPublisher<(CBConnectionEvent, Peripheral), Never>
-  public let didDiscoverPeripheral: AnyPublisher<PeripheralDiscovery, Never>
-  
-  public let didUpdateACNSAuthorizationForPeripheral: AnyPublisher<Peripheral, Never>
+  public var didUpdateACNSAuthorizationForPeripheral: AnyPublisher<Peripheral, Never>
   
   public var state: CBManagerState {
     _state()

--- a/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
@@ -7,38 +7,38 @@ public struct Peripheral: Sendable {
   let rawValue: CBPeripheral?
   let delegate: Delegate?
 
-  var _name: @Sendable () -> String?
-  var _identifier: @Sendable () -> UUID
-  var _state: @Sendable () -> CBPeripheralState
-  var _services: @Sendable () -> [CBService]?
-  var _canSendWriteWithoutResponse: @Sendable () -> Bool
+  public var _name: @Sendable () -> String?
+  public var _identifier: @Sendable () -> UUID
+  public var _state: @Sendable () -> CBPeripheralState
+  public var _services: @Sendable () -> [CBService]?
+  public var _canSendWriteWithoutResponse: @Sendable () -> Bool
 
-  var _ancsAuthorized: @Sendable () -> Bool
+  public var _ancsAuthorized: @Sendable () -> Bool
 
-  var _readRSSI: @Sendable () -> Void
-  var _discoverServices: @Sendable (_ serviceUUIDs: [CBUUID]?) -> Void
-  var _discoverIncludedServices: @Sendable (_ includedServiceUUIDs: [CBUUID]?, _ service: CBService) -> Void
-  var _discoverCharacteristics: @Sendable (_ characteristicUUIDs: [CBUUID]?, _ service: CBService) -> Void
-  var _readValueForCharacteristic: @Sendable (_ characteristic: CBCharacteristic) -> Void
-  var _maximumWriteValueLength: @Sendable (_ type: CBCharacteristicWriteType) -> Int
-  var _writeValueForCharacteristic: @Sendable (_ data: Data, _ characteristic: CBCharacteristic, _ type: CBCharacteristicWriteType) -> Void
-  var _setNotifyValue: @Sendable (_ enabled: Bool, _ characteristic: CBCharacteristic) -> Void
-  var _discoverDescriptors: @Sendable (_ characteristic: CBCharacteristic) -> Void
-  var _readValueForDescriptor: @Sendable (_ descriptor: CBDescriptor) -> Void
-  var _writeValueForDescriptor: @Sendable (_ data: Data, _ descriptor: CBDescriptor) -> Void
-  var _openL2CAPChannel: @Sendable (_ PSM: CBL2CAPPSM) -> Void
+  public var _readRSSI: @Sendable () -> Void
+  public var _discoverServices: @Sendable (_ serviceUUIDs: [CBUUID]?) -> Void
+  public var _discoverIncludedServices: @Sendable (_ includedServiceUUIDs: [CBUUID]?, _ service: CBService) -> Void
+  public var _discoverCharacteristics: @Sendable (_ characteristicUUIDs: [CBUUID]?, _ service: CBService) -> Void
+  public var _readValueForCharacteristic: @Sendable (_ characteristic: CBCharacteristic) -> Void
+  public var _maximumWriteValueLength: @Sendable (_ type: CBCharacteristicWriteType) -> Int
+  public var _writeValueForCharacteristic: @Sendable (_ data: Data, _ characteristic: CBCharacteristic, _ type: CBCharacteristicWriteType) -> Void
+  public var _setNotifyValue: @Sendable (_ enabled: Bool, _ characteristic: CBCharacteristic) -> Void
+  public var _discoverDescriptors: @Sendable (_ characteristic: CBCharacteristic) -> Void
+  public var _readValueForDescriptor: @Sendable (_ descriptor: CBDescriptor) -> Void
+  public var _writeValueForDescriptor: @Sendable (_ data: Data, _ descriptor: CBDescriptor) -> Void
+  public var _openL2CAPChannel: @Sendable (_ PSM: CBL2CAPPSM) -> Void
 
-  var didReadRSSI:                             AnyPublisher<Result<Double, Error>, Never>
-  var didDiscoverServices:                     AnyPublisher<([CBService], Error?), Never>
-  var didDiscoverIncludedServices:             AnyPublisher<(CBService, Error?), Never>
-  var didDiscoverCharacteristics:              AnyPublisher<(CBService, Error?), Never>
-  var didUpdateValueForCharacteristic:         AnyPublisher<(CBCharacteristic, Error?), Never>
-  var didWriteValueForCharacteristic:          AnyPublisher<(CBCharacteristic, Error?), Never>
-  var didUpdateNotificationState:              AnyPublisher<(CBCharacteristic, Error?), Never>
-  var didDiscoverDescriptorsForCharacteristic: AnyPublisher<(CBCharacteristic, Error?), Never>
-  var didUpdateValueForDescriptor:             AnyPublisher<(CBDescriptor, Error?), Never>
-  var didWriteValueForDescriptor:              AnyPublisher<(CBDescriptor, Error?), Never>
-  var didOpenChannel:                          AnyPublisher<(L2CAPChannel?, Error?), Never>
+  public var didReadRSSI:                             AnyPublisher<Result<Double, Error>, Never>
+  public var didDiscoverServices:                     AnyPublisher<([CBService], Error?), Never>
+  public var didDiscoverIncludedServices:             AnyPublisher<(CBService, Error?), Never>
+  public var didDiscoverCharacteristics:              AnyPublisher<(CBService, Error?), Never>
+  public var didUpdateValueForCharacteristic:         AnyPublisher<(CBCharacteristic, Error?), Never>
+  public var didWriteValueForCharacteristic:          AnyPublisher<(CBCharacteristic, Error?), Never>
+  public var didUpdateNotificationState:              AnyPublisher<(CBCharacteristic, Error?), Never>
+  public var didDiscoverDescriptorsForCharacteristic: AnyPublisher<(CBCharacteristic, Error?), Never>
+  public var didUpdateValueForDescriptor:             AnyPublisher<(CBDescriptor, Error?), Never>
+  public var didWriteValueForDescriptor:              AnyPublisher<(CBDescriptor, Error?), Never>
+  public var didOpenChannel:                          AnyPublisher<(L2CAPChannel?, Error?), Never>
 
   public var isReadyToSendWriteWithoutResponse: AnyPublisher<Void, Never>
   public var nameUpdates: AnyPublisher<String?, Never>

--- a/Sources/CombineCoreBluetooth/PeripheralManager/Interface+PeripheralManager.swift
+++ b/Sources/CombineCoreBluetooth/PeripheralManager/Interface+PeripheralManager.swift
@@ -4,31 +4,31 @@ import Foundation
 public struct PeripheralManager: Sendable {
   let delegate: Delegate?
 
-  let _state: @Sendable () -> CBManagerState
-  let _authorization: @Sendable () -> CBManagerAuthorization
-  let _isAdvertising: @Sendable () -> Bool
-  let _startAdvertising: @Sendable (_ advertisementData: AdvertisementData?) -> Void
-  let _stopAdvertising: @Sendable () -> Void
-  let _setDesiredConnectionLatency: @Sendable (_ latency: CBPeripheralManagerConnectionLatency, _ central: Central) -> Void
-  let _add: @Sendable (_ service: CBMutableService) -> Void
-  let _remove: @Sendable (_ service: CBMutableService) -> Void
-  let _removeAllServices: @Sendable () -> Void
-  let _respondToRequest: @Sendable (_ request: ATTRequest, _ result: CBATTError.Code) -> Void
-  let _updateValueForCharacteristic: @Sendable (_ value: Data, _ characteristic: CBMutableCharacteristic, _ centrals: [Central]?) -> Bool
-  let _publishL2CAPChannel: @Sendable (_ encryptionRequired: Bool) -> Void
-  let _unpublishL2CAPChannel: @Sendable (_ PSM: CBL2CAPPSM) -> Void
+  public var _state: @Sendable () -> CBManagerState
+  public var _authorization: @Sendable () -> CBManagerAuthorization
+  public var _isAdvertising: @Sendable () -> Bool
+  public var _startAdvertising: @Sendable (_ advertisementData: AdvertisementData?) -> Void
+  public var _stopAdvertising: @Sendable () -> Void
+  public var _setDesiredConnectionLatency: @Sendable (_ latency: CBPeripheralManagerConnectionLatency, _ central: Central) -> Void
+  public var _add: @Sendable (_ service: CBMutableService) -> Void
+  public var _remove: @Sendable (_ service: CBMutableService) -> Void
+  public var _removeAllServices: @Sendable () -> Void
+  public var _respondToRequest: @Sendable (_ request: ATTRequest, _ result: CBATTError.Code) -> Void
+  public var _updateValueForCharacteristic: @Sendable (_ value: Data, _ characteristic: CBMutableCharacteristic, _ centrals: [Central]?) -> Bool
+  public var _publishL2CAPChannel: @Sendable (_ encryptionRequired: Bool) -> Void
+  public var _unpublishL2CAPChannel: @Sendable (_ PSM: CBL2CAPPSM) -> Void
 
-  public let didUpdateState: AnyPublisher<CBManagerState, Never>
-  public let didStartAdvertising: AnyPublisher<Error?, Never>
-  public let didAddService: AnyPublisher<(CBService, Error?), Never>
-  public let centralDidSubscribeToCharacteristic: AnyPublisher<(Central, CBCharacteristic), Never>
-  public let centralDidUnsubscribeFromCharacteristic: AnyPublisher<(Central, CBCharacteristic), Never>
-  public let didReceiveReadRequest: AnyPublisher<ATTRequest, Never>
-  public let didReceiveWriteRequests: AnyPublisher<[ATTRequest], Never>
-  public let readyToUpdateSubscribers: AnyPublisher<Void, Never>
-  public let didPublishL2CAPChannel: AnyPublisher<(CBL2CAPPSM, Error?), Never>
-  public let didUnpublishL2CAPChannel: AnyPublisher<(CBL2CAPPSM, Error?), Never>
-  public let didOpenL2CAPChannel: AnyPublisher<(L2CAPChannel?, Error?), Never>
+  public var didUpdateState: AnyPublisher<CBManagerState, Never>
+  public var didStartAdvertising: AnyPublisher<Error?, Never>
+  public var didAddService: AnyPublisher<(CBService, Error?), Never>
+  public var centralDidSubscribeToCharacteristic: AnyPublisher<(Central, CBCharacteristic), Never>
+  public var centralDidUnsubscribeFromCharacteristic: AnyPublisher<(Central, CBCharacteristic), Never>
+  public var didReceiveReadRequest: AnyPublisher<ATTRequest, Never>
+  public var didReceiveWriteRequests: AnyPublisher<[ATTRequest], Never>
+  public var readyToUpdateSubscribers: AnyPublisher<Void, Never>
+  public var didPublishL2CAPChannel: AnyPublisher<(CBL2CAPPSM, Error?), Never>
+  public var didUnpublishL2CAPChannel: AnyPublisher<(CBL2CAPPSM, Error?), Never>
+  public var didOpenL2CAPChannel: AnyPublisher<(L2CAPChannel?, Error?), Never>
 
   public var state: CBManagerState {
     _state()


### PR DESCRIPTION
This is to make it easier to add decorating functionality to all main types, or to selectively alter specific functions that get called by the convenience API.