### PR TITLE
Fix bugs in demo app

### DIFF
--- a/CentralPeripheralDemo/CentralView.swift
+++ b/CentralPeripheralDemo/CentralView.swift
@@ -47,9 +47,9 @@ class CentralDemo: ObservableObject {
   func connect(_ discovery: PeripheralDiscovery) {
     centralManager.connect(discovery.peripheral)
       .map(Result.success)
-      .catch({ Just(Result.failure($0)) })
-        .receive(on: DispatchQueue.main)
-        .assign(to: &$peripheralConnectResult)
+      .catch { Just(Result.failure($0)) }
+      .receive(on: DispatchQueue.main)
+      .assign(to: &$peripheralConnectResult)
   }
 }
 

--- a/CentralPeripheralDemo/PeripheralView.swift
+++ b/CentralPeripheralDemo/PeripheralView.swift
@@ -66,13 +66,13 @@ class PeripheralDemo: ObservableObject {
   }
 
   func start() {
-    buildServices()
-      
     peripheralManager.startAdvertising(.init([.serviceUUIDs: [CBUUID.service]]))
+      .receive(on: DispatchQueue.main)
       .sink(receiveCompletion: { c in
         
       }, receiveValue: { [weak self] _ in
         self?.advertising = true
+        self?.buildServices()
       })
       .store(in: &cancellables)
   }


### PR DESCRIPTION
- Fix main queue problem when advertising as a peripheral
- don't build services until we start advertising to avoid an api misuse problem where peripheralmanager expects bluetooth to be powered on before adding services

This should fix #27 i believe.