### PR TITLE
Fix API MISUSE warning when creating a CentralManager or PeripheralManager without a restore identifier

### DIFF
--- a/Sources/CombineCoreBluetooth/CentralManager/Interface+CentralManager.swift
+++ b/Sources/CombineCoreBluetooth/CentralManager/Interface+CentralManager.swift
@@ -172,7 +172,7 @@ public struct CentralManager: Sendable {
   }
   
   @objc(CCBCentralManagerDelegate)
-  final class Delegate: NSObject, Sendable {
+  class Delegate: NSObject, @unchecked Sendable {
     let didUpdateState: PassthroughSubject<CBManagerState, Never> = .init()
     let willRestoreState: PassthroughSubject<[String: Any], Never> = .init()
     let didConnectPeripheral: PassthroughSubject<Peripheral, Never> = .init()
@@ -181,5 +181,8 @@ public struct CentralManager: Sendable {
     let connectionEventDidOccur: PassthroughSubject<(CBConnectionEvent, Peripheral), Never> = .init()
     let didDiscoverPeripheral: PassthroughSubject<PeripheralDiscovery, Never> = .init()
     let didUpdateACNSAuthorizationForPeripheral: PassthroughSubject<Peripheral, Never> = .init()
+  }
+  
+  class RestorableDelegate: Delegate {
   }
 }

--- a/Sources/CombineCoreBluetooth/CentralManager/Interface+CentralManager.swift
+++ b/Sources/CombineCoreBluetooth/CentralManager/Interface+CentralManager.swift
@@ -183,6 +183,7 @@ public struct CentralManager: Sendable {
     let didUpdateACNSAuthorizationForPeripheral: PassthroughSubject<Peripheral, Never> = .init()
   }
   
+  @objc(CCBCentralManagerRestorableDelegate)
   class RestorableDelegate: Delegate {
   }
 }

--- a/Sources/CombineCoreBluetooth/CentralManager/Live+CentralManager.swift
+++ b/Sources/CombineCoreBluetooth/CentralManager/Live+CentralManager.swift
@@ -4,7 +4,7 @@ import Foundation
 
 extension CentralManager {
   public static func live(_ options: ManagerCreationOptions? = nil) -> Self {
-    let delegate: Delegate = options?.restoreIdentifierKey != nil ? RestorableDelegate() : Delegate()
+    let delegate: Delegate = options?.restoreIdentifier != nil ? RestorableDelegate() : Delegate()
     let centralManager = CBCentralManager(
       delegate: delegate,
       queue: DispatchQueue(label: "combine-core-bluetooth.central-manager", target: .global()),

--- a/Sources/CombineCoreBluetooth/CentralManager/Live+CentralManager.swift
+++ b/Sources/CombineCoreBluetooth/CentralManager/Live+CentralManager.swift
@@ -4,10 +4,10 @@ import Foundation
 
 extension CentralManager {
   public static func live(_ options: ManagerCreationOptions? = nil) -> Self {
-    let delegate = Delegate()
+    let delegate: Delegate = options?.restoreIdentifierKey != nil ? RestorableDelegate() : Delegate()
     let centralManager = CBCentralManager(
       delegate: delegate,
-      queue: DispatchQueue(label: "com.combine-core-bluetooth.central", target: .global()),
+      queue: DispatchQueue(label: "combine-core-bluetooth.central-manager", target: .global()),
       options: options?.centralManagerDictionary
     )
     
@@ -90,10 +90,6 @@ extension CentralManager.Delegate: CBCentralManagerDelegate {
     didUpdateState.send(central.state)
   }
   
-  func centralManager(_ central: CBCentralManager, willRestoreState dict: [String : Any]) {
-    willRestoreState.send(dict)
-  }
-  
   func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
     didConnectPeripheral.send(Peripheral(cbperipheral: peripheral))
   }
@@ -125,4 +121,10 @@ extension CentralManager.Delegate: CBCentralManagerDelegate {
     didUpdateACNSAuthorizationForPeripheral.send(Peripheral(cbperipheral: peripheral))
   }
 #endif
+}
+
+extension CentralManager.RestorableDelegate {
+  func centralManager(_ central: CBCentralManager, willRestoreState dict: [String : Any]) {
+    willRestoreState.send(dict)
+  }
 }

--- a/Sources/CombineCoreBluetooth/Models/ManagerCreationOptions.swift
+++ b/Sources/CombineCoreBluetooth/Models/ManagerCreationOptions.swift
@@ -5,24 +5,35 @@ public struct ManagerCreationOptions: Sendable {
   /// If true, display a warning dialog to the user when the manager is instantiated if Bluetooth is powered off
   public var showPowerAlert: Bool?
   /// A unique identifier for the manager that's being instantiated. This identifier is used by the system to identify a specific  manager instance for restoration and, therefore, must remain the same for subsequent application executions in order for the manager to be restored.
-  public var restoreIdentifierKey: String?
+  public var restoreIdentifier: String?
   
-  public init(showPowerAlert: Bool? = nil, restoreIdentifierKey: String? = nil) {
+  public init(showPowerAlert: Bool? = nil, restoreIdentifier: String? = nil) {
     self.showPowerAlert = showPowerAlert
-    self.restoreIdentifierKey = restoreIdentifierKey
+    self.restoreIdentifier = restoreIdentifier
   }
   
   var centralManagerDictionary: [String: Any] {
     var dict: [String: Any] = [:]
     dict[CBCentralManagerOptionShowPowerAlertKey] = showPowerAlert
-    dict[CBCentralManagerOptionRestoreIdentifierKey] = restoreIdentifierKey
+    dict[CBCentralManagerOptionRestoreIdentifierKey] = restoreIdentifier
     return dict
   }
   
   var peripheralManagerDictionary: [String: Any] {
     var dict: [String: Any] = [:]
     dict[CBPeripheralManagerOptionShowPowerAlertKey] = showPowerAlert
-    dict[CBPeripheralManagerOptionRestoreIdentifierKey] = restoreIdentifierKey
+    dict[CBPeripheralManagerOptionRestoreIdentifierKey] = restoreIdentifier
     return dict
+  }
+  
+  @available(*, deprecated, renamed: "restoreIdentifier")
+  public var restoreIdentifierKey: String? {
+    get { restoreIdentifier }
+    set { restoreIdentifier = newValue }
+  }
+  
+  @available(*, deprecated, renamed: "init(showPowerAlert:restoreIdentifier:)")
+  public init(showPowerAlert: Bool? = nil, restoreIdentifierKey: String?) {
+    self.init(showPowerAlert: showPowerAlert, restoreIdentifier: restoreIdentifierKey)
   }
 }

--- a/Sources/CombineCoreBluetooth/PeripheralManager/Interface+PeripheralManager.swift
+++ b/Sources/CombineCoreBluetooth/PeripheralManager/Interface+PeripheralManager.swift
@@ -148,6 +148,7 @@ extension PeripheralManager {
     let didOpenL2CAPChannel:                     PassthroughSubject<(L2CAPChannel?, Error?), Never>     = .init()
   }
   
+  @objc(CCBPeripheralManagerRestorableDelegate)
   class RestorableDelegate: Delegate {
     
   }

--- a/Sources/CombineCoreBluetooth/PeripheralManager/Interface+PeripheralManager.swift
+++ b/Sources/CombineCoreBluetooth/PeripheralManager/Interface+PeripheralManager.swift
@@ -133,7 +133,7 @@ public struct PeripheralManager: Sendable {
 
 extension PeripheralManager {
   @objc(CCBPeripheralManagerDelegate)
-  final class Delegate: NSObject, Sendable {
+  class Delegate: NSObject, @unchecked Sendable {
     let didUpdateState:                          PassthroughSubject<CBManagerState, Never>              = .init()
     let willRestoreState:                        PassthroughSubject<[String: Any], Never>               = .init()
     let didStartAdvertising:                     PassthroughSubject<Error?, Never>                      = .init()
@@ -146,5 +146,9 @@ extension PeripheralManager {
     let didPublishL2CAPChannel:                  PassthroughSubject<(CBL2CAPPSM, Error?), Never>        = .init()
     let didUnpublishL2CAPChannel:                PassthroughSubject<(CBL2CAPPSM, Error?), Never>        = .init()
     let didOpenL2CAPChannel:                     PassthroughSubject<(L2CAPChannel?, Error?), Never>     = .init()
+  }
+  
+  class RestorableDelegate: Delegate {
+    
   }
 }

--- a/Sources/CombineCoreBluetooth/PeripheralManager/Live+PeripheralManager.swift
+++ b/Sources/CombineCoreBluetooth/PeripheralManager/Live+PeripheralManager.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension PeripheralManager {
   public static func live(_ options: ManagerCreationOptions? = nil) -> Self {
-    let delegate: Delegate = options?.restoreIdentifierKey != nil ? RestorableDelegate() : Delegate()
+    let delegate: Delegate = options?.restoreIdentifier != nil ? RestorableDelegate() : Delegate()
 #if os(tvOS) || os(watchOS)
     let peripheralManager = CBPeripheralManager()
     peripheralManager.delegate = delegate


### PR DESCRIPTION
- Fix api misuse log warning by only using willRestoreState delegates if the caller provides a restoration identifier
- rename manager creation option property to be more precise
