### PR TITLE
Add peripheral didUpdateMTU method

### DIFF
--- a/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Interface+Peripheral.swift
@@ -39,6 +39,7 @@ public struct Peripheral: Sendable {
   public var didUpdateValueForDescriptor:             AnyPublisher<(CBDescriptor, Error?), Never>
   public var didWriteValueForDescriptor:              AnyPublisher<(CBDescriptor, Error?), Never>
   public var didOpenChannel:                          AnyPublisher<(L2CAPChannel?, Error?), Never>
+  public var didUpdateMTU:                            AnyPublisher<Int, Never>
 
   public var isReadyToSendWriteWithoutResponse: AnyPublisher<Void, Never>
   public var nameUpdates: AnyPublisher<String?, Never>
@@ -474,6 +475,7 @@ extension Peripheral {
     let didWriteValueForDescriptor:              PassthroughSubject<(CBDescriptor, Error?), Never>     = .init()
     let isReadyToSendWriteWithoutResponse:       PassthroughSubject<Void, Never>                       = .init()
     let didOpenChannel:                          PassthroughSubject<(L2CAPChannel?, Error?), Never>    = .init()
+    let didUpdateMTU:                            PassthroughSubject<Int, Never>                        = .init()
   }
 }
 

--- a/Sources/CombineCoreBluetooth/Peripheral/Live+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Live+Peripheral.swift
@@ -46,6 +46,7 @@ extension Peripheral {
       didUpdateValueForDescriptor: delegate.didUpdateValueForDescriptor.eraseToAnyPublisher(),
       didWriteValueForDescriptor: delegate.didWriteValueForDescriptor.eraseToAnyPublisher(),
       didOpenChannel: delegate.didOpenChannel.eraseToAnyPublisher(),
+      didUpdateMTU: delegate.didUpdateMTU.eraseToAnyPublisher(),
 
       isReadyToSendWriteWithoutResponse: delegate.isReadyToSendWriteWithoutResponse.eraseToAnyPublisher(),
       nameUpdates: delegate.nameUpdates.eraseToAnyPublisher(),
@@ -113,5 +114,9 @@ extension Peripheral.Delegate: CBPeripheralDelegate {
 
   func peripheral(_ peripheral: CBPeripheral, didOpen channel: CBL2CAPChannel?, error: Error?) {
     didOpenChannel.send((channel.map(L2CAPChannel.init(channel:)), error))
+  }
+
+  func peripheral(_ peripheral: CBPeripheral, didUpdateMTU mtu: Int) {
+    didUpdateMTU.send(mtu)
   }
 }

--- a/Sources/CombineCoreBluetooth/Peripheral/Mock+Peripheral.swift
+++ b/Sources/CombineCoreBluetooth/Peripheral/Mock+Peripheral.swift
@@ -31,6 +31,7 @@ extension Peripheral {
     didUpdateValueForDescriptor:             AnyPublisher<(CBDescriptor, Error?), Never> = _Internal._unimplemented("didUpdateValueForDescriptor"),
     didWriteValueForDescriptor:              AnyPublisher<(CBDescriptor, Error?), Never> = _Internal._unimplemented("didWriteValueForDescriptor"),
     didOpenChannel:                          AnyPublisher<(L2CAPChannel?, Error?), Never> = _Internal._unimplemented("didOpenChannel"),
+    didUpdateMTU:                            AnyPublisher<Int, Never> = _Internal._unimplemented("didUpdateMTU"),
     isReadyToSendWriteWithoutResponse:       AnyPublisher<Void, Never> = _Internal._unimplemented("isReadyToSendWriteWithoutResponse"),
     nameUpdates:                             AnyPublisher<String?, Never> = _Internal._unimplemented("nameUpdates"),
     invalidatedServiceUpdates:               AnyPublisher<[CBService], Never> = _Internal._unimplemented("invalidatedServiceUpdates")
@@ -68,6 +69,7 @@ extension Peripheral {
       didUpdateValueForDescriptor: didUpdateValueForDescriptor,
       didWriteValueForDescriptor: didWriteValueForDescriptor,
       didOpenChannel: didOpenChannel,
+      didUpdateMTU: didUpdateMTU,
 
       isReadyToSendWriteWithoutResponse: isReadyToSendWriteWithoutResponse,
       nameUpdates: nameUpdates,


### PR DESCRIPTION
This is useful when MTU negotiation happens and the user needs the final value for app logic.
